### PR TITLE
feat: create CLIENTS_REQUIRING_RESTART filter

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -11,6 +11,8 @@ import { exec } from 'child_process'
 const execAsync = promisify(exec)
 
 export default class Install extends Command {
+  private CLIENTS_REQUIRING_RESTART: string[] = ['claude']
+  
   private clientDisplayNames: Record<string, string> = {
     'claude': 'Claude Desktop',
     'continue': 'Continue'
@@ -379,7 +381,9 @@ export default class Install extends Command {
       }
 
       // After successful installation, prompt for restart
-      await this.promptForRestart(flags.client)
+      if (this.CLIENTS_REQUIRING_RESTART.includes(flags.client)) {
+        await this.promptForRestart(flags.client)
+      }
     } catch (error: unknown) {
       if (error instanceof Error) {
         this.error(`Failed to install server: ${error.message}`)


### PR DESCRIPTION
Noticed when installing `filesystem-ref` that I was prompted to restart Continue at the end - this isn't necessary since writes to `config.json` are automatically picked up by Continue.

