### PR TITLE
add artemis mcp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentools",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentools",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opentools",
   "description": "The easiest way to install MCP servers",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "author": "OpenTools Team",
   "bin": {
     "opentools": "./bin/run.js"

--- a/src/data/servers/index.ts
+++ b/src/data/servers/index.ts
@@ -2,6 +2,34 @@ import type { MCPServerType } from '../types.js'
 
 export const servers: MCPServerType[] = [
   {
+    id: 'artemis',
+    name: 'Artemis Analytics',
+    description: 'Pull the latest fundamental crypto data from Artemis natively into you favorite chatbot interface.',
+    publisher: {
+      id: 'Artemis-xyz',
+      name: 'Artemis Analytics Inc.',
+      url: 'https://www.artemis.xyz/',
+    },
+    isOfficial: true,
+    sourceUrl: 'https://github.com/Artemis-xyz/artemis-mcp',
+    distribution: {
+      type: 'pip',
+      package: 'artemis-mcp',
+    },
+    license: 'MIT',
+    runtime: 'python',
+    config:
+      {
+        command: 'uvx',
+        args: ['artemis-mcp'],
+        env: {
+          ARTEMIS_API_KEY: {
+            description: 'Your Artemis API key from https://app.artemis.xyz/settings.',
+          }
+        }
+    }
+  },
+  {
     id: "aws-kb-retrieval-server-ref",
     name: "AWS Knowledge Base",
     description: "Retrieval from AWS Knowledge Base using Bedrock Agent Runtime. A Model Context Protocol reference server.",


### PR DESCRIPTION
This PR adds https://github.com/Artemis-xyz/artemis-mcp as an installable server to the CLI. Of note - artemis-mcp will to merge my as-of-yet-PR-ed [fork](https://github.com/jameselkins/artemis-mcp) & publish that new version to pypi before this "uvx artemis-mcp" will work